### PR TITLE
Dockerfile cleanup

### DIFF
--- a/dockerfile/almost_base
+++ b/dockerfile/almost_base
@@ -1,9 +1,11 @@
 FROM ubuntu:14.04
 MAINTAINER flant <256@flant.com>
 
-RUN apt-get update -q
-RUN apt-get install -y supervisor
-RUN apt-get install -y tree
+RUN apt-get update -q && \
+    apt-get install -y supervisor && \
+    apt-get install -y tree && \
+    apt-get clean && 
+    rm -rf /var/lib/apt/lists/*
 
 RUN /bin/bash -lec "\
 mkdir /.config; \

--- a/dockerfile/base
+++ b/dockerfile/base
@@ -1,8 +1,10 @@
 FROM ubuntu:14.04
 MAINTAINER flant <256@flant.com>
 
-RUN apt-get update -q
-RUN apt-get install -y supervisor
+RUN apt-get update -q && \
+    apt-get install -y supervisor && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN /bin/bash -lec "\
 mkdir /.config; \

--- a/dockerfile/mux
+++ b/dockerfile/mux
@@ -1,6 +1,8 @@
 FROM ubuntu:14.04
 MAINTAINER flant <256@flant.com>
 
-RUN apt-get update -q
-RUN apt-get install -y supervisor
-RUN apt-get install -y php5-fpm
+RUN apt-get update -q && \
+    apt-get install -y supervisor && \
+    apt-get install -y php5-fpm && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This should shrink the size of the docker containers at the expense of less caching between the images.

Another trade off would be to shrink the docker container size at the expense of build time, by wrapping the apt-get update in its own RUN step, and then the install of other software in its own RUN step.
