### PR TITLE
address CVE-2019-13354 in dependency

### DIFF
--- a/superhosting.gemspec
+++ b/superhosting.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'unicode', '~> 0.4'
   spec.add_dependency 'punycode4r', '~> 0.2'
   spec.add_dependency 'polling', '~> 0.1.5'
-  spec.add_dependency 'strong_password', '~> 0.0.5'
+  spec.add_dependency 'strong_password', '~> 0.0.8'
   spec.add_dependency 'mysql2', '~> 0.4.3'
 
   spec.add_development_dependency 'bundler', '~> 1.7'


### PR DESCRIPTION
pull in latest version to ensure that the vulnerable `0.0.7` version is never used. It would send the password to an attacker by posting it to pastebin.

https://withatwist.dev/strong-password-rubygem-hijacked.html